### PR TITLE
derive rawbson from a given value

### DIFF
--- a/examples/demo/main.zig
+++ b/examples/demo/main.zig
@@ -43,12 +43,7 @@ pub fn main() !void {
             if (v.get("hello")) |value| {
                 std.debug.print(
                     "deserialized hello '{s}'!",
-                    .{
-                        switch (value) {
-                            .string => |s| s,
-                            else => unreachable,
-                        },
-                    },
+                    .{value},
                 );
             }
         },

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -3,7 +3,7 @@ const types = @import("types.zig");
 const RawBson = types.RawBson;
 
 /// A Reader deserializes BSON bytes from a provided Reader type
-/// into a RawBson type, typically a RawBson.document with embedded BSON types,  following the [BSON spec](https://bsonspec.org/spec.html)
+/// into a RawBson type, typically a RawBson.document with embedded BSON types, following the [BSON spec](https://bsonspec.org/spec.html)
 pub fn Reader(comptime T: type) type {
     return struct {
         reader: std.io.CountingReader(T),
@@ -153,7 +153,11 @@ pub fn Reader(comptime T: type) type {
         }
 
         inline fn readCStr(self: *@This()) ![]u8 {
-            return (try self.reader.reader().readUntilDelimiterAlloc(self.arena.allocator(), 0, std.math.maxInt(usize)));
+            return (try self.reader.reader().readUntilDelimiterAlloc(
+                self.arena.allocator(),
+                0,
+                std.math.maxInt(usize),
+            ));
         }
 
         inline fn readStr(self: *@This()) ![]u8 {
@@ -189,7 +193,7 @@ pub fn Reader(comptime T: type) type {
 }
 
 /// Creates a new BSON reader to deserialize documents from bytes provided by an underlying reader
-/// Callers should call `deinit()` on after using the writer
+/// Callers should call `deinit()` on after using the reader
 pub fn reader(allocator: std.mem.Allocator, underlying: anytype) Reader(@TypeOf(underlying)) {
     return Reader(@TypeOf(underlying)).init(allocator, underlying);
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -9,6 +9,20 @@ pub const reader = @import("reader.zig").reader;
 pub const writer = @import("writer.zig").writer;
 pub const types = @import("types.zig");
 
+/// A container for a value and its deferable deinitialization
+pub fn Owned(comptime T: type) type {
+    return struct {
+        value: T,
+        arena: *std.heap.ArenaAllocator,
+        /// call this to deinitialize value after use
+        pub fn deinit(self: *@This()) void {
+            const alloc = self.arena.child_allocator;
+            self.arena.deinit();
+            alloc.destroy(self.arena);
+        }
+    };
+}
+
 test {
     std.testing.refAllDecls(@This());
 }

--- a/src/types.zig
+++ b/src/types.zig
@@ -518,6 +518,7 @@ pub const RawBson = union(enum) {
                     },
                 }
             },
+            // .Float ...
             .Array => |v| blk: {
                 var elements = try owned.arena.allocator().alloc(RawBson, v.len);
                 for (data, 0..) |elem, i| {
@@ -626,7 +627,11 @@ test "RawBson.from" {
         .person = .{
             .age = 32,
             .id = try RawBson.objectIdHex("507f1f77bcf86cd799439011"),
-            .ary = &[_]i32{ 1, 2, 3 },
+            .comp_int = 1,
+            .i32 = @as(i32, 2),
+            .i64 = @as(i64, 3),
+            .ary = [_]i32{ 4, 5, 6 },
+            .slice = &[_]i32{ 1, 2, 3 },
         },
     });
     defer doc.deinit();

--- a/src/types.zig
+++ b/src/types.zig
@@ -848,9 +848,7 @@ test "RawBson.from" {
         },
     });
     defer doc.deinit();
-    const actual = try std.json.stringifyAlloc(allocator, doc.value, .{});
-    defer allocator.free(actual);
-    std.debug.print("doc {s}", .{actual});
+    std.debug.print("doc {s}", .{doc.value});
 }
 
 test "RawBson.jsonStringify" {

--- a/src/types.zig
+++ b/src/types.zig
@@ -630,9 +630,9 @@ test "RawBson.from" {
         },
     });
     defer doc.deinit();
-    //const actual = try std.json.stringifyAlloc(allocator, doc, .{});
-    //defer allocator.free(actual);
-    std.debug.print("doc {?any}", .{doc.value.document.get("person").?.document.get("ary").?.array});
+    const actual = try std.json.stringifyAlloc(allocator, doc.value, .{});
+    defer allocator.free(actual);
+    std.debug.print("doc {s}", .{actual});
 }
 
 test "RawBson.jsonStringify" {

--- a/src/types.zig
+++ b/src/types.zig
@@ -507,6 +507,7 @@ pub const RawBson = union(enum) {
                 }
                 break :blk RawBson.document(fields);
             },
+            .Bool => RawBson.boolean(data),
             .ComptimeInt => RawBson.int32(data),
             .Int => |v| blk: {
                 switch (v.bits) {
@@ -625,13 +626,13 @@ test "RawBson.from" {
     const allocator = std.testing.allocator;
     var doc = try RawBson.from(allocator, .{
         .person = .{
-            .age = 32,
             .id = try RawBson.objectIdHex("507f1f77bcf86cd799439011"),
             .comp_int = 1,
             .i32 = @as(i32, 2),
             .i64 = @as(i64, 3),
             .ary = [_]i32{ 4, 5, 6 },
             .slice = &[_]i32{ 1, 2, 3 },
+            .bool = true,
         },
     });
     defer doc.deinit();

--- a/src/types.zig
+++ b/src/types.zig
@@ -772,6 +772,17 @@ pub const RawBson = union(enum) {
         };
     }
 
+    pub fn format(
+        self: @This(),
+        comptime _: []const u8,
+        _: std.fmt.FormatOptions,
+        writer: anytype,
+    ) !void {
+        var jw = std.json.writeStream(writer, .{});
+        defer jw.deinit();
+        try jw.write(self);
+    }
+
     pub fn deinit(self: @This(), allocator: std.mem.Allocator) void {
         switch (self) {
             .document => |v| {

--- a/src/types.zig
+++ b/src/types.zig
@@ -532,13 +532,14 @@ pub const RawBson = union(enum) {
                             break :blk RawBson.string(data);
                         }
                         var elements = try std.ArrayList(RawBson).init(owned.arena.allocator());
-                        for (@field(data, data)) |
+                        for (data) |
                             elem,
                         | {
                             try elements.append((try from(owned.arena.allocator(), elem)).value);
                         }
                         break :blk RawBson.array(try elements.toOwnedSlice());
                     },
+                    .One => break :blk (try from(owned.arena.allocator(), data.*)).value,
                     else => |otherwise| {
                         std.debug.print("{any} pointer types not yet supported\n", .{otherwise});
                         unreachable;
@@ -625,7 +626,7 @@ test "RawBson.from" {
         .person = .{
             .age = 32,
             .id = try RawBson.objectIdHex("507f1f77bcf86cd799439011"),
-            .ary = [_]i32{ 1, 2, 3 },
+            .ary = &[_]i32{ 1, 2, 3 },
         },
     });
     defer doc.deinit();

--- a/src/types.zig
+++ b/src/types.zig
@@ -595,11 +595,11 @@ pub const RawBson = union(enum) {
 
 test "RawBson.from" {
     const allocator = std.testing.allocator;
-    var doc = try RawBson.from(allocator, .{ .age = 32 });
+    var doc = try RawBson.from(allocator, .{ .person = .{ .age = 32 } });
     defer doc.deinit();
     //const actual = try std.json.stringifyAlloc(allocator, doc, .{});
     //defer allocator.free(actual);
-    std.debug.print("doc {?any}", .{doc.value.document.get("age")});
+    std.debug.print("doc {?any}", .{doc.value.document.get("person").?.document.get("age")});
 }
 
 test "RawBson.jsonStringify" {


### PR DESCRIPTION
in a number of cases it would be much more convenient to express documents in native zig struct types. this pull allows for converting  raw bson <=> native zig types 