### PR TITLE
return Owned type from reader.read to defer release of memory

### DIFF
--- a/examples/demo/main.zig
+++ b/examples/demo/main.zig
@@ -37,8 +37,9 @@ pub fn main() !void {
     // read it back
     var fbs = std.io.fixedBufferStream(bytes);
     var reader = bson.reader(allocator, fbs.reader());
-    defer reader.deinit();
-    switch (try reader.read()) {
+    var rawBson = try reader.read();
+    defer rawBson.deinit();
+    switch (rawBson.value) {
         .document => |v| {
             if (v.get("hello")) |value| {
                 std.debug.print(

--- a/examples/demo/main.zig
+++ b/examples/demo/main.zig
@@ -14,7 +14,30 @@ pub fn main() !void {
             .{ "hello", RawBson.string("world") },
         },
     );
+    const bytes = try serialize(allocator, doc);
+    defer allocator.free(bytes);
+    std.debug.print("{s}", .{std.fmt.fmtSliceHexLower(bytes)});
 
+    // read it back
+    var rawBson = try deserialize(allocator, bytes);
+    defer rawBson.deinit();
+    switch (rawBson.value) {
+        .document => |v| {
+            if (v.get("hello")) |value| {
+                std.debug.print("deserialized hello '{s}'!", .{value});
+            }
+        },
+        else => unreachable,
+    }
+}
+
+fn deserialize(allocator: std.mem.Allocator, bytes: []const u8) !bson.Owned(RawBson) {
+    var fbs = std.io.fixedBufferStream(bytes);
+    var reader = bson.reader(allocator, fbs.reader());
+    return try reader.read();
+}
+
+fn serialize(allocator: std.mem.Allocator, doc: RawBson) ![]const u8 {
     // write a document to a byte buffer
     var buf = std.ArrayList(u8).init(allocator);
     defer buf.deinit();
@@ -25,29 +48,5 @@ pub fn main() !void {
     defer writer.deinit();
     try writer.write(doc);
 
-    const bytes = try buf.toOwnedSlice();
-    defer allocator.free(bytes);
-    std.debug.print(
-        "{s}",
-        .{
-            std.fmt.fmtSliceHexLower(bytes),
-        },
-    );
-
-    // read it back
-    var fbs = std.io.fixedBufferStream(bytes);
-    var reader = bson.reader(allocator, fbs.reader());
-    var rawBson = try reader.read();
-    defer rawBson.deinit();
-    switch (rawBson.value) {
-        .document => |v| {
-            if (v.get("hello")) |value| {
-                std.debug.print(
-                    "deserialized hello '{s}'!",
-                    .{value},
-                );
-            }
-        },
-        else => unreachable,
-    }
+    return try buf.toOwnedSlice();
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -124,14 +124,15 @@ test "bson specs" {
                     allocator,
                     stream.reader(),
                 );
-                defer bsonReader.deinit();
+                //defer bsonReader.deinit();
 
                 if (suite.test_key) |_| {
-                    const rawBson = try bsonReader.read();
+                    var rawBson = try bsonReader.read();
+                    defer rawBson.deinit();
 
                     const actual = try std.json.stringifyAlloc(
                         allocator,
-                        rawBson,
+                        rawBson.value,
                         .{},
                     );
                     defer allocator.free(actual);

--- a/src/writer.zig
+++ b/src/writer.zig
@@ -15,7 +15,7 @@ pub fn Writer(comptime T: type) type {
             };
         }
 
-        /// callers sure ensure this is called to free an allocated memory
+        /// callers should ensure this is called to free an allocated memory
         pub fn deinit(self: *@This()) void {
             self.arena.deinit();
         }

--- a/src/writer.zig
+++ b/src/writer.zig
@@ -165,10 +165,11 @@ test Writer {
     const stream = fbs.reader();
 
     var bsonReader = reader(allocator, stream);
-    defer bsonReader.deinit();
+    var rawBson = try bsonReader.read();
+    defer rawBson.deinit();
     const actual = try std.json.stringifyAlloc(
         allocator,
-        try bsonReader.read(),
+        rawBson.value,
         .{},
     );
     defer allocator.free(actual);


### PR DESCRIPTION
at present, allocated memory in read ops is deallocated with the reader. RawBson values tend to need to live on much longer that the readers/writers

lets follow the pattern of zigs json parsing which return a Parsed type, in our case these will returned an Owned type