### PR TITLE
Fix syntax errors and build issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ---
 
-[![Main](https://github.com/softprops/zig-bson/actions/workflows/ci.yml/badge.svg)](https://github.com/softprops/zig-bson/actions/workflows/ci.yml) ![License Info](https://img.shields.io/github/license/softprops/zig-bson) ![Release](https://img.shields.io/github/v/release/softprops/zig-bson) [![Zig Support](https://img.shields.io/badge/zig-0.13.0-black?logo=zig)](https://ziglang.org/documentation/0.13.0/)
+[![Main](https://github.com/softprops/zig-bson/actions/workflows/ci.yml/badge.svg)](https://github.com/softprops/zig-bson/actions/workflows/ci.yml) ![License Info](https://img.shields.io/github/license/softprops/zig-bson) ![Release](https://img.shields.io/github/v/release/softprops/zig-bson) [![Zig Support](https://img.shields.io/badge/zig-0.14.0-black?logo=zig)](https://ziglang.org/documentation/0.14.0/)
 
 
 ## examples

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
-    .name = "bson",
-    .version = "0.1.4",
+    .name = .bson,
+    .version = "0.1.5",
     .dependencies = .{
         // todo: update this to a versioned tag when this package publishes one
         .benchmark = .{
@@ -8,7 +8,8 @@
             .hash = "1220287c22cfcf85f05d353084e12200c6a7dcb5f4511cb05103f5dbd709e50731a7",
         },
     },
-    .minimum_zig_version = "0.13.0",
+    .minimum_zig_version = "0.14.0",
+    .fingerprint = 0xaeb30daac4c1f602,
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/examples/demo/main.zig
+++ b/examples/demo/main.zig
@@ -9,11 +9,16 @@ pub fn main() !void {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    const doc = RawBson.document(
+    const doc = try RawBson.createDocument(
         &.{
             .{ "hello", RawBson.string("world") },
         },
+        allocator
     );
+
+    // RawBson.createDocument allocates memory to store the name and Bson value
+    // so it needs to be freed
+    defer doc.deinit(allocator);
 
     // write a document to a byte buffer
     const bytes = try serialize(allocator, doc);

--- a/src/root.zig
+++ b/src/root.zig
@@ -83,7 +83,7 @@ test "bson specs" {
         if (std.mem.startsWith(u8, entry.path, "decimal")) {
             continue;
         }
-        var pathBuf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+        var pathBuf: [std.fs.max_path_bytes]u8 = undefined;
         var file = try fs.openFileAbsolute(
             try fs.Dir.realpath(specs, entry.path, &pathBuf),
             .{},
@@ -114,7 +114,7 @@ test "bson specs" {
                 }
                 std.debug.print("{s}: {s}\n", .{ suite.description, valid.description });
                 // each of these are essentially a mini document with test_key as a key and some test suite specific bson typed value
-                var bsonBuf: [std.mem.page_size]u8 = undefined;
+                var bsonBuf: [4*1024]u8 = undefined; // Hard code a *sensible* buf size
                 const bson = try std.fmt.hexToBytes(&bsonBuf, valid.canonical_bson);
 
                 //std.debug.print("raw (bytes) {any}\n", .{bson});

--- a/src/writer.zig
+++ b/src/writer.zig
@@ -43,7 +43,7 @@ pub fn Writer(comptime T: type) type {
                         try docWriter.writeInt(i8, elem.@"1".toType().toInt());
                         _ = try docWriter.writeAll(elem.@"0");
                         try docWriter.writeSentinelByte();
-                        try docWriter.write(elem.@"1");
+                        try docWriter.write(elem.@"1".*);
                     }
 
                     // we add 5 to account for 1. the 4 byte len itself and 2. 1 extra null byte at the end
@@ -145,24 +145,26 @@ test Writer {
     var bsonWriter = writer(allocator, buf.writer());
     defer bsonWriter.deinit();
 
-    const doc = RawBson.document(
+    const doc = try RawBson.createDocument(
         &.{
-            .{ "a", types.RawBson.string("a") },
-            .{ "b", types.RawBson.boolean(true) },
-            .{ "c", types.RawBson.minKey() },
-            .{ "d", types.RawBson.maxKey() },
-            .{ "e", types.RawBson.array(
+            .{ "a", types.RawBson.makeString("a") },
+            .{ "b", types.RawBson.makeBoolean(true) },
+            .{ "c", types.RawBson.makeMinKey() },
+            .{ "d", types.RawBson.makeMaxKey() },
+            .{ "e", types.RawBson.makeArray(
                 &[_]RawBson{
-                    RawBson.int32(10),
-                    RawBson.int32(11),
-                    RawBson.int32(12),
+                    RawBson.makeInt32(10),
+                    RawBson.makeInt32(11),
+                    RawBson.makeInt32(12),
                 },
             ) },
-            .{ "f", RawBson.datetime(0) },
-            .{ "g", RawBson.double(1.23) },
-            .{ "h", try RawBson.objectIdHex("56e1fc72e0c917e9c4714161") },
+            .{ "f", RawBson.makeDatetime(0) },
+            .{ "g", RawBson.makeDouble(1.23) },
+            .{ "h", try RawBson.makeObjectIdHex("56e1fc72e0c917e9c4714161") },
         },
+        allocator
     );
+    defer doc.deinit(allocator);
     try bsonWriter.write(doc);
     const written = try buf.toOwnedSlice();
     defer allocator.free(written);


### PR DESCRIPTION
Fixed several issues

- Updated build.zig.zon for updated version
- Updated build.zig.zon to use zig 0.14.0
- Changed build.zig.zon to use an enum instead of string for the name
- Fixed syntax errors associated with RawBson methods and tags being the same
- Fixed struct Document depends on itself by storing a RawBson pointer for elements instead
- Updated calls to typeInfo API
- Fixed misc issues in root.zig

If you twist my arm I'll update to 0.15.1, but I'm working on something that needs this for 0.14. 